### PR TITLE
x774 logging config

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 sprint.cors-origins=http://localhost:8080, http://sprint.psd.sanger.ac.uk, http://uat.lighthouse-ui.psd.sanger.ac.uk, http://lighthouse-ui.psd.sanger.ac.uk
+logging.file.max-history=0
+logging.file.total-size-cap=1GB


### PR DESCRIPTION
SPrint is actually running an older version of Spring, and as far as
I can tell doesn't delete old logs. But I'm adding the settings
for futureproofing.

logging.file.max-history=0: keep logs forever
logging.file.total-size-cap=1GB: until their total size reaches 1 GB
