### PR TITLE
Add lighthouse HTTPS origin to app properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,3 @@
-sprint.cors-origins=http://localhost:8080, http://sprint.psd.sanger.ac.uk, http://uat.lighthouse-ui.psd.sanger.ac.uk, http://lighthouse-ui.psd.sanger.ac.uk
+sprint.cors-origins=http://localhost:8080, http://sprint.psd.sanger.ac.uk, http://uat.lighthouse-ui.psd.sanger.ac.uk, https://uat.lighthouse-ui.psd.sanger.ac.uk, http://training.lighthouse-ui.psd.sanger.ac.uk, https://training.lighthouse-ui.psd.sanger.ac.uk, http://lighthouse-ui.psd.sanger.ac.uk, https://lighthouse-ui.psd.sanger.ac.uk
 logging.file.max-history=0
 logging.file.total-size-cap=1GB


### PR DESCRIPTION
Hi, 
This is required for one of our stories https://github.com/sanger/deployment/issues/106, to support both HTTP and HTTPS for Lighthouse UI. 
I've added HTTPS origin and training as that wasn't there before.
Sorry about the long list, Chris mentioned that regex may not be supported or I would have tried that
Thank you