### PR TITLE
x814 https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>uk.ac.sanger</groupId>
     <artifactId>sprint</artifactId>
-    <version>0.3.4</version>
+    <version>0.3.5</version>
     <name>SPrint</name>
     <description>Simple print service</description>
 

--- a/src/main/java/uk/ac/sanger/sprint/SPrintApplication.java
+++ b/src/main/java/uk/ac/sanger/sprint/SPrintApplication.java
@@ -1,13 +1,33 @@
 package uk.ac.sanger.sprint;
 
+import org.apache.catalina.connector.Connector;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class SPrintApplication {
+
+    @Value("${http.port:0}")
+    private int httpPort;
 
     public static void main(String[] args) {
         SpringApplication.run(SPrintApplication.class, args);
     }
 
+    // Configure additional connector to enable support for both http and https
+    @Bean
+    public ServletWebServerFactory servletContainer() {
+        TomcatServletWebServerFactory tomcat = new TomcatServletWebServerFactory();
+        if (httpPort != 0) {
+            Connector connector = new Connector("org.apache.coyote.http11.Http11NioProtocol");
+            connector.setScheme("http");
+            connector.setPort(httpPort);
+            tomcat.addAdditionalTomcatConnectors(connector);
+        }
+        return tomcat;
+    }
 }


### PR DESCRIPTION
Add support for an additional http connection on a port specified in config.
We change the config in sprint-deployment to be set up for https, and
also specify the http port. The new code here adds an additional
connector for the http port.