### PR TITLE
Cassette

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>uk.ac.sanger</groupId>
     <artifactId>sprint</artifactId>
-    <version>0.3.8</version>
+    <version>0.3.9</version>
     <name>SPrint</name>
     <description>Simple print service</description>
 

--- a/src/main/java/uk/ac/sanger/sprint/GraphQLDataFetchers.java
+++ b/src/main/java/uk/ac/sanger/sprint/GraphQLDataFetchers.java
@@ -85,9 +85,9 @@ public class GraphQLDataFetchers {
                 throw new IllegalArgumentException("Unknown printer without explicit printer type: "+printerName);
             }
             if (printer==null) {
-                printer = new Printer(printerName, printerType, null);
+                printer = new Printer(printerName, printerType, null, null);
             } else if (printerType!=null) {
-                printer = new Printer(printer.getHostname(), printerType, printer.getLabelType());
+                printer = new Printer(printer.getHostname(), printerType, printer.getLabelType(), null);
             }
 
             String jobId = printService.print(req, printer);

--- a/src/main/java/uk/ac/sanger/sprint/config/AppConfig.java
+++ b/src/main/java/uk/ac/sanger/sprint/config/AppConfig.java
@@ -16,7 +16,7 @@ public class AppConfig {
 
     @Bean
     public Clock clock() {
-        return Clock.systemDefaultZone();
+        return Clock.systemUTC();
     }
 
     public String getVolume() {

--- a/src/main/java/uk/ac/sanger/sprint/config/AppConfig.java
+++ b/src/main/java/uk/ac/sanger/sprint/config/AppConfig.java
@@ -1,0 +1,25 @@
+package uk.ac.sanger.sprint.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+/**
+ * @author dr6
+ */
+@Configuration
+public class AppConfig {
+    @Value("${sprint.volume}")
+    private String volume;
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+
+    public String getVolume() {
+        return this.volume;
+    }
+}

--- a/src/main/java/uk/ac/sanger/sprint/config/ConfigLoaderImplementation.java
+++ b/src/main/java/uk/ac/sanger/sprint/config/ConfigLoaderImplementation.java
@@ -1,15 +1,18 @@
 package uk.ac.sanger.sprint.config;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.ac.sanger.sprint.model.*;
 
 import javax.xml.bind.JAXBException;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.nio.file.*;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static uk.ac.sanger.sprint.utils.BasicUtils.nullToEmpty;
 
 /**
  * Injectable implementation of {@code ConfigLoader}
@@ -17,13 +20,17 @@ import java.util.stream.Collectors;
  */
 @Component
 class ConfigLoaderImplementation implements ConfigLoader {
-    private ThrowingFunction<Path, PrinterConfig, JAXBException> printerConfigLoader;
+    private final AppConfig appConfig;
 
-    public ConfigLoaderImplementation() {
-        this(null);
+    private final ThrowingFunction<Path, PrinterConfig, JAXBException> printerConfigLoader;
+
+    @Autowired
+    public ConfigLoaderImplementation(AppConfig appConfig) {
+        this(appConfig, null);
     }
 
-    public ConfigLoaderImplementation(ThrowingFunction<Path, PrinterConfig, JAXBException> printerConfigLoader) {
+    public ConfigLoaderImplementation(AppConfig appConfig, ThrowingFunction<Path, PrinterConfig, JAXBException> printerConfigLoader) {
+        this.appConfig = appConfig;
         this.printerConfigLoader = (printerConfigLoader==null ? PrinterConfig::load : printerConfigLoader);
     }
 
@@ -33,11 +40,13 @@ class ConfigLoaderImplementation implements ConfigLoader {
         try {
             for (Path path : paths) {
                 if (Files.isDirectory(path)) {
-                    Iterator<Path> pathIter = Files.list(path)
-                            .filter(subPath -> Files.isRegularFile(subPath) && hasExtension(subPath, ".xml"))
-                            .iterator();
-                    while (pathIter.hasNext()) {
-                        configs.add(printerConfigLoader.apply(pathIter.next()));
+                    try (Stream<Path> pathStream = Files.list(path)) {
+                        Iterator<Path> pathIter = pathStream
+                                .filter(subPath -> Files.isRegularFile(subPath) && hasExtension(subPath, ".xml"))
+                                .iterator();
+                        while (pathIter.hasNext()) {
+                            configs.add(printerConfigLoader.apply(pathIter.next()));
+                        }
                     }
                 } else {
                     configs.add(printerConfigLoader.apply(path));
@@ -53,9 +62,10 @@ class ConfigLoaderImplementation implements ConfigLoader {
         final Map<String, PrinterType> printerTypes = configs.stream()
                 .flatMap(cf -> cf.getPrinterTypes().stream())
                 .collect(Collectors.toMap(PrinterType::getName, Function.identity()));
+        final String volumePath = appConfig.getVolume();
         Map<String, Printer> printers = configs.stream()
                 .flatMap(cf -> cf.getEntries().stream())
-                .map(e -> toPrinter(e, printerTypes, labelTypes))
+                .map(e -> toPrinter(e, printerTypes, labelTypes, volumePath))
                 .collect(Collectors.toMap(Printer::getHostname, Function.identity()));
 
         for (Printer printer: printers.values()) {
@@ -66,7 +76,8 @@ class ConfigLoaderImplementation implements ConfigLoader {
         return new Config(printers, new ArrayList<>(labelTypes.values()), printerTypes);
     }
 
-    private static Printer toPrinter(PrinterEntry e, Map<String, PrinterType> printerTypes, Map<String, LabelType> labelTypes) {
+    private static Printer toPrinter(PrinterEntry e, Map<String, PrinterType> printerTypes,
+                                     Map<String, LabelType> labelTypes, String volumePath) {
         PrinterType printerType = printerTypes.get(e.getPrinterType());
         if (printerType==null) {
             throw new RuntimeException("Unknown printer type: "+e.getPrinterType());
@@ -75,7 +86,8 @@ class ConfigLoaderImplementation implements ConfigLoader {
         if (labelType==null) {
             throw new RuntimeException("Unknown label type: "+e.getLabelType());
         }
-        return new Printer(e.getHostname(), printerType, labelType);
+        Path path = (e.getPath()==null ? null : Paths.get(nullToEmpty(volumePath), e.getPath()));
+        return new Printer(e.getHostname(), printerType, labelType, path);
     }
 
     private static boolean hasExtension(Path path, String extension) {

--- a/src/main/java/uk/ac/sanger/sprint/config/PrinterConfig.java
+++ b/src/main/java/uk/ac/sanger/sprint/config/PrinterConfig.java
@@ -1,5 +1,6 @@
 package uk.ac.sanger.sprint.config;
 
+import org.springframework.context.annotation.Bean;
 import uk.ac.sanger.sprint.model.LabelType;
 import uk.ac.sanger.sprint.model.PrinterType;
 

--- a/src/main/java/uk/ac/sanger/sprint/config/PrinterEntry.java
+++ b/src/main/java/uk/ac/sanger/sprint/config/PrinterEntry.java
@@ -11,6 +11,7 @@ class PrinterEntry {
     private String hostname;
     private String labelType;
     private String printerType;
+    private String path;
 
     public String getHostname() {
         return this.hostname;
@@ -34,5 +35,13 @@ class PrinterEntry {
 
     public void setPrinterType(String printerType) {
         this.printerType = printerType;
+    }
+
+    public String getPath() {
+        return this.path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
     }
 }

--- a/src/main/java/uk/ac/sanger/sprint/model/KeyField.java
+++ b/src/main/java/uk/ac/sanger/sprint/model/KeyField.java
@@ -1,0 +1,54 @@
+package uk.ac.sanger.sprint.model;
+
+import java.util.Objects;
+
+/**
+ * A field associated with a key (string) rather than a position
+ * @author dr6
+ */
+public class KeyField {
+    private String key;
+    private String value;
+
+    public KeyField() {}
+
+    public KeyField(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return this.key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("(%s=%s)", key, value);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        KeyField that = (KeyField) o;
+        return (Objects.equals(this.key, that.key)
+                && Objects.equals(this.value, that.value));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, value);
+    }
+}

--- a/src/main/java/uk/ac/sanger/sprint/model/Layout.java
+++ b/src/main/java/uk/ac/sanger/sprint/model/Layout.java
@@ -2,8 +2,9 @@ package uk.ac.sanger.sprint.model;
 
 import com.google.common.base.MoreObjects;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
+
+import static uk.ac.sanger.sprint.utils.BasicUtils.nullToEmpty;
 
 /**
  * The contents of one label in a print request.
@@ -11,6 +12,7 @@ import java.util.List;
 public class Layout {
     private List<TextField> textFields = Collections.emptyList();
     private List<BarcodeField> barcodeFields = Collections.emptyList();
+    private List<KeyField> keyFields = Collections.emptyList();
     private LabelSize labelSize;
 
     /**
@@ -26,7 +28,7 @@ public class Layout {
      * @param textFields the new text fields in this layout
      */
     public void setTextFields(List<TextField> textFields) {
-        this.textFields = textFields;
+        this.textFields = nullToEmpty(textFields);
     }
 
     /**
@@ -42,7 +44,23 @@ public class Layout {
      * @param barcodeFields the new barcode fields in this layout
      */
     public void setBarcodeFields(List<BarcodeField> barcodeFields) {
-        this.barcodeFields = barcodeFields;
+        this.barcodeFields = nullToEmpty(barcodeFields);
+    }
+
+    /**
+     * Gets the key fields in this layout
+     * @return the key fields in this layout
+     */
+    public List<KeyField> getKeyFields() {
+        return this.keyFields;
+    }
+
+    /**
+     * Sets the key fields in this layout
+     * @param keyFields the key fields in this layout
+     */
+    public void setKeyFields(List<KeyField> keyFields) {
+        this.keyFields = nullToEmpty(keyFields);
     }
 
     /**
@@ -62,12 +80,41 @@ public class Layout {
         this.labelSize = labelSize;
     }
 
+    /**
+     * Creates a new layout with the given keyfields
+     * @param keyFields the keyfields for the layout
+     * @return a new layout with the given keyfields
+     */
+    public static Layout ofKeyFields(List<KeyField> keyFields) {
+        Layout ly = new Layout();
+        ly.setKeyFields(keyFields);
+        return ly;
+    }
+
+    /**
+     * Creates a new layout with the given strings as keyfields
+     * @param keysValues the keys and values for the fields, alternating key then value
+     * @return a new layout with the given keyfields
+     * @exception IllegalArgumentException if an odd number of <tt>keysValues</tt> is given
+     */
+    public static Layout ofKeyFields(String... keysValues) {
+        if (keysValues.length%2!=0) {
+            throw new IllegalArgumentException("Expected an even number for keysValues");
+        }
+        List<KeyField> keyFields = new ArrayList<>(keysValues.length/2);
+        for (int i = 0; i < keysValues.length; i += 2) {
+            keyFields.add(new KeyField(keysValues[i], keysValues[i+1]));
+        }
+        return ofKeyFields(keyFields);
+    }
+
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("labelSize", labelSize)
                 .add("textFields", textFields)
                 .add("barcodeFields", barcodeFields)
+                .add("keyFields", keyFields)
                 .toString();
     }
 }

--- a/src/main/java/uk/ac/sanger/sprint/model/Printer.java
+++ b/src/main/java/uk/ac/sanger/sprint/model/Printer.java
@@ -2,6 +2,7 @@ package uk.ac.sanger.sprint.model;
 
 import com.google.common.base.MoreObjects;
 
+import java.nio.file.Path;
 import java.util.Objects;
 
 /**
@@ -11,6 +12,7 @@ public class Printer {
     private String hostname;
     private LabelType labelType;
     private PrinterType printerType;
+    private Path path;
 
     /**
      * Constructs a new printer with default values for every field
@@ -22,11 +24,13 @@ public class Printer {
      * @param hostname the hostname of the printer
      * @param printerType the type of printer
      * @param labelType the type of label supported by the printer
+     * @param path the file path for this printer
      */
-    public Printer(String hostname, PrinterType printerType, LabelType labelType) {
+    public Printer(String hostname, PrinterType printerType, LabelType labelType, Path path) {
         this.hostname = hostname;
         this.printerType = printerType;
         this.labelType = labelType;
+        this.path = path;
     }
 
     /**
@@ -81,12 +85,21 @@ public class Printer {
         return (hostname.indexOf('.') < 0) ? hostname + ".internal.sanger.ac.uk" : hostname;
     }
 
+    public Path getPath() {
+        return this.path;
+    }
+
+    public void setPath(Path path) {
+        this.path = path;
+    }
+
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("hostname", hostname)
                 .add("labelType", labelType)
                 .add("printerType", printerType)
+                .add("path", path)
                 .toString();
     }
 
@@ -97,11 +110,12 @@ public class Printer {
         Printer that = (Printer) o;
         return (Objects.equals(this.hostname, that.hostname)
                 && Objects.equals(this.labelType, that.labelType)
-                && Objects.equals(this.printerType, that.printerType));
+                && Objects.equals(this.printerType, that.printerType)
+                && Objects.equals(this.path, that.path));
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(hostname);
+        return (hostname==null ? 0 : hostname.hashCode());
     }
 }

--- a/src/main/java/uk/ac/sanger/sprint/model/PrinterLanguage.java
+++ b/src/main/java/uk/ac/sanger/sprint/model/PrinterLanguage.java
@@ -4,5 +4,6 @@ package uk.ac.sanger.sprint.model;
  * A language for a printer; i.e. an indication of how to produce data that the printer will understand
  */
 public enum PrinterLanguage {
-    JSCRIPT
+    JSCRIPT,
+    CSV,
 }

--- a/src/main/java/uk/ac/sanger/sprint/model/Protocol.java
+++ b/src/main/java/uk/ac/sanger/sprint/model/Protocol.java
@@ -4,5 +4,10 @@ package uk.ac.sanger.sprint.model;
  * The protocol used to send a print request
  */
 public enum Protocol {
-    FTP, STUB
+    /** Send over FTP */
+    FTP,
+    /** Copy to a mounted volume */
+    VOLUME,
+    /** Validate the request */
+    STUB,
 }

--- a/src/main/java/uk/ac/sanger/sprint/service/language/CsvAdapter.java
+++ b/src/main/java/uk/ac/sanger/sprint/service/language/CsvAdapter.java
@@ -1,0 +1,41 @@
+package uk.ac.sanger.sprint.service.language;
+
+import uk.ac.sanger.sprint.model.KeyField;
+import uk.ac.sanger.sprint.model.PrintRequest;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.joining;
+
+/**
+ * An adapter for a csv file.
+ * Requests are expected to include keyfields, whose values are inserted in the order given.
+ * @author dr6
+ */
+public class CsvAdapter implements PrinterLanguageAdapter {
+    private final String valueSeparator;
+
+    public CsvAdapter(String valueSeparator) {
+        this.valueSeparator = valueSeparator;
+    }
+
+    @Override
+    public String transcribe(PrintRequest request, String jobId) {
+        return request.getLayouts().stream()
+                .map(ly -> this.transcribeKeyFields(ly.getKeyFields()))
+                .collect(joining("\n"));
+    }
+
+    String sanitiseValue(String value) {
+        if (value==null) {
+            return "";
+        }
+        return value.replace(valueSeparator, " ").replaceAll("\\s+", " ");
+    }
+
+    String transcribeKeyFields(List<KeyField> keyFields) {
+        return keyFields.stream()
+                .map(kf -> sanitiseValue(kf.getValue()))
+                .collect(joining(valueSeparator));
+    }
+}

--- a/src/main/java/uk/ac/sanger/sprint/service/language/PrinterLanguageAdapterFactoryImplementation.java
+++ b/src/main/java/uk/ac/sanger/sprint/service/language/PrinterLanguageAdapterFactoryImplementation.java
@@ -9,8 +9,11 @@ public class PrinterLanguageAdapterFactoryImplementation implements PrinterLangu
     @Override
     public PrinterLanguageAdapter getLanguageAdapter(Printer printer) {
         PrinterLanguage language = printer.getPrinterType().getLanguage();
-        if (language == PrinterLanguage.JSCRIPT) {
-            return new JScriptAdapter(printer);
+        if (language!=null) {
+            switch (language) {
+                case JSCRIPT: return new JScriptAdapter(printer);
+                case CSV: return new CsvAdapter(",");
+            }
         }
         throw new UnsupportedOperationException("Unsupported printer language: "+language);
     }

--- a/src/main/java/uk/ac/sanger/sprint/service/protocol/PrintProtocolAdapterFactoryImplementation.java
+++ b/src/main/java/uk/ac/sanger/sprint/service/protocol/PrintProtocolAdapterFactoryImplementation.java
@@ -1,26 +1,43 @@
 package uk.ac.sanger.sprint.service.protocol;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.stereotype.Component;
 import uk.ac.sanger.sprint.model.Printer;
 import uk.ac.sanger.sprint.model.Protocol;
+import uk.ac.sanger.sprint.utils.UniqueInstantSupplier;
 
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.util.List;
 
 @Component
 public class PrintProtocolAdapterFactoryImplementation implements PrintProtocolAdapterFactory {
     private final FTPStoreFactory ftpStoreFactory;
+    private final UniqueInstantSupplier uniqueInstantSupplier;
     private final String ipAddress;
+    private final DateTimeFormatter timeFormat;
 
+    @Autowired
     public PrintProtocolAdapterFactoryImplementation(FTPStoreFactory ftpStoreFactory,
-                                                     ApplicationArguments arguments) {
+                                                     ApplicationArguments arguments,
+                                                     UniqueInstantSupplier uniqueInstantSupplier) {
         this.ftpStoreFactory = ftpStoreFactory;
+        this.uniqueInstantSupplier = uniqueInstantSupplier;
         List<String> ipAddressArg = arguments.getOptionValues("ipAddress");
         if (ipAddressArg!=null && !ipAddressArg.isEmpty()) {
             this.ipAddress = ipAddressArg.get(0);
         } else {
             this.ipAddress = null;
         }
+        this.timeFormat = makeDateTimeFormatter();
+    }
+
+    public static DateTimeFormatter makeDateTimeFormatter() {
+        return new DateTimeFormatterBuilder()
+                .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                .appendLiteral(".csv")
+                .toFormatter();
     }
 
     @Override
@@ -29,6 +46,7 @@ public class PrintProtocolAdapterFactoryImplementation implements PrintProtocolA
         if (protocol!=null) {
             switch (protocol) {
                 case FTP: return new FtpPrintProtocolAdapter(printer, ftpStoreFactory, ipAddress);
+                case VOLUME: return new VolumeProtocolAdapter(printer, timeFormat, uniqueInstantSupplier);
                 case STUB: return new StubPrintProtocolAdapter();
             }
         }

--- a/src/main/java/uk/ac/sanger/sprint/service/protocol/StubPrintProtocolAdapter.java
+++ b/src/main/java/uk/ac/sanger/sprint/service/protocol/StubPrintProtocolAdapter.java
@@ -1,13 +1,18 @@
 package uk.ac.sanger.sprint.service.protocol;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 
 /**
  * @author dr6
  */
 public class StubPrintProtocolAdapter implements PrintProtocolAdapter {
+    static Logger log = LoggerFactory.getLogger(StubPrintProtocolAdapter.class);
+
     @Override
     public void print(String printCode) throws IOException {
-        // Nothing happens
+        log.info("Print code: {}", printCode);
     }
 }

--- a/src/main/java/uk/ac/sanger/sprint/service/protocol/VolumeProtocolAdapter.java
+++ b/src/main/java/uk/ac/sanger/sprint/service/protocol/VolumeProtocolAdapter.java
@@ -1,0 +1,42 @@
+package uk.ac.sanger.sprint.service.protocol;
+
+import uk.ac.sanger.sprint.model.Printer;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.util.function.Supplier;
+
+import static java.util.Collections.singletonList;
+
+/**
+ * Adapter for copying request data to a file mounted locally
+ * @author dr6
+ */
+public class VolumeProtocolAdapter implements PrintProtocolAdapter {
+    public static final String TMP_EXT = "_TEMP";
+    private final Printer printer;
+    private final Supplier<Instant> instantSupplier;
+    private final DateTimeFormatter timeFormat;
+
+    public VolumeProtocolAdapter(Printer printer, DateTimeFormatter timeFormat, Supplier<Instant> instantSupplier) {
+        this.printer = printer;
+        this.timeFormat = timeFormat;
+        this.instantSupplier = instantSupplier;
+    }
+
+    String newFilename() {
+        return LocalDateTime.ofInstant(instantSupplier.get(), ZoneOffset.UTC).format(timeFormat);
+
+    }
+
+    @Override
+    public void print(String printCode) throws IOException {
+        String filename = newFilename();
+        Path savePath = printer.getPath().resolve(filename + TMP_EXT);
+        Files.write(savePath, singletonList(printCode));
+        Path finalPath = printer.getPath().resolve(filename);
+        Files.move(savePath, finalPath);
+    }
+}

--- a/src/main/java/uk/ac/sanger/sprint/utils/BasicUtils.java
+++ b/src/main/java/uk/ac/sanger/sprint/utils/BasicUtils.java
@@ -1,5 +1,8 @@
 package uk.ac.sanger.sprint.utils;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * @author dr6
  */
@@ -22,5 +25,13 @@ public class BasicUtils {
             return StringRepr.repr((char) o);
         }
         return o.toString();
+    }
+
+    public static <E> List<E> nullToEmpty(List<E> list) {
+        return (list==null ? Collections.emptyList() : list);
+    }
+
+    public static String nullToEmpty(String string) {
+        return (string==null ? "" : string);
     }
 }

--- a/src/main/java/uk/ac/sanger/sprint/utils/UniqueInstantSupplier.java
+++ b/src/main/java/uk/ac/sanger/sprint/utils/UniqueInstantSupplier.java
@@ -1,0 +1,48 @@
+package uk.ac.sanger.sprint.utils;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Utility for getting a unique time at or closely after the actual current time.
+ * @author dr6
+ */
+@Component
+public class UniqueInstantSupplier implements Supplier<Instant> {
+    private final AtomicReference<Instant> lastInstant = new AtomicReference<>();
+    private final Clock clock;
+
+    /**
+     * Creates a new unique timestamp supplier
+     * @param clock the clock to use for the time
+     */
+    @Autowired
+    public UniqueInstantSupplier(Clock clock) {
+        this.clock = requireNonNull(clock, "clock is null");
+    }
+
+    /**
+     * Gets the unique time
+     * @return A new instant approximately now but definitely after previous calls
+     */
+    @Override
+    public Instant get() {
+        Instant now = clock.instant();
+        while (true) {
+            Instant last = lastInstant.get();
+            if (last!=null && !now.isAfter(last)) {
+                now = last.plusNanos(1);
+            }
+            if (lastInstant.compareAndSet(last, now)) {
+                return now;
+            }
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 sprint.cors-origins=http://localhost:8080, http://sprint.psd.sanger.ac.uk, http://uat.lighthouse-ui.psd.sanger.ac.uk, https://uat.lighthouse-ui.psd.sanger.ac.uk, http://training.lighthouse-ui.psd.sanger.ac.uk, https://training.lighthouse-ui.psd.sanger.ac.uk, http://lighthouse-ui.psd.sanger.ac.uk, https://lighthouse-ui.psd.sanger.ac.uk
 logging.file.max-history=0
 logging.file.total-size-cap=1GB
+sprint.volume=

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -104,6 +104,8 @@ input Layout {
     barcodeFields: [BarcodeField!]
     # The text fields on the label
     textFields: [TextField!]
+    # The key fields for the label
+    keyFields: [KeyField!]
     # Optionally override the label size for this label. This is compulsory if the printer you are printing to
     # is not in config.
     labelSize: LabelSize
@@ -150,5 +152,13 @@ input TextField {
     # The font size in mm
     fontSize: Float!
     # The value of this text
+    value: String!
+}
+
+# A key and value
+input KeyField {
+    # The key
+    key: String!
+    # The value
     value: String!
 }

--- a/src/test/java/uk/ac/sanger/sprint/config/ConfigLoaderTest.java
+++ b/src/test/java/uk/ac/sanger/sprint/config/ConfigLoaderTest.java
@@ -11,6 +11,8 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
 /**
@@ -27,6 +29,8 @@ public class ConfigLoaderTest {
 
     @BeforeClass
     private void setup() {
+        AppConfig appConfig = mock(AppConfig.class);
+        when(appConfig.getVolume()).thenReturn("mnt/sprint");
         printerTypes = Arrays.asList(
                 new PrinterType("PT0", PrinterLanguage.JSCRIPT, Protocol.FTP, null, new Credentials("alpha", "beta"),
                         new Credentials("gamma", "delta")),
@@ -37,13 +41,13 @@ public class ConfigLoaderTest {
                 new LabelType(12, 22, 32, "lt1")
         );
         printers = Arrays.asList(
-                new Printer("p0", printerTypes.get(0), labelTypes.get(0)),
-                new Printer("p1", printerTypes.get(0), labelTypes.get(1)),
-                new Printer("p2", printerTypes.get(1), labelTypes.get(0))
+                new Printer("p0", printerTypes.get(0), labelTypes.get(0), null),
+                new Printer("p1", printerTypes.get(0), labelTypes.get(1), null),
+                new Printer("p2", printerTypes.get(1), labelTypes.get(0), null)
         );
 
         paths = Arrays.asList(Paths.get("printers", "printers.xml"), Paths.get("boo"));
-        configLoader = new ConfigLoaderImplementation(this::loadPrinterConfig);
+        configLoader = new ConfigLoaderImplementation(appConfig, this::loadPrinterConfig);
     }
 
     private static PrinterEntry entry(Printer printer) {

--- a/src/test/java/uk/ac/sanger/sprint/service/PrintServiceTest.java
+++ b/src/test/java/uk/ac/sanger/sprint/service/PrintServiceTest.java
@@ -2,8 +2,7 @@ package uk.ac.sanger.sprint.service;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.testng.annotations.*;
 import uk.ac.sanger.sprint.model.*;
 import uk.ac.sanger.sprint.service.language.PrinterLanguageAdapter;
 import uk.ac.sanger.sprint.service.language.PrinterLanguageAdapterFactory;
@@ -18,7 +17,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 import static org.testng.Assert.*;
 
 /**
@@ -49,10 +48,11 @@ public class PrintServiceTest {
     private PrintService service;
 
     private final String printCode = "MyPrintCode";
+    private AutoCloseable mocking;
 
     @BeforeMethod
     private void setupMocks() {
-        initMocks(this);
+        mocking = openMocks(this);
         when(mockLanguageAdapterFactory.getLanguageAdapter(any())).thenReturn(mockLanguageAdapter);
         when(mockProtocolAdapterFactory.getPrintProtocolAdapter(any())).thenReturn(mockProtocolAdapter);
         when(mockStatusAdapterFactory.getStatusProtocolAdapter(any())).thenReturn(mockStatusAdapter);
@@ -60,6 +60,11 @@ public class PrintServiceTest {
         when(mockLanguageAdapter.transcribe(any(), any())).thenReturn(printCode);
 
         service = new PrintServiceImplementation(mockLanguageAdapterFactory, mockProtocolAdapterFactory, mockStatusAdapterFactory);
+    }
+
+    @AfterMethod
+    private void releaseMocks() throws Exception {
+        mocking.close();
     }
 
     private void mockPrinter(StatusProtocol statusProtocol) {

--- a/src/test/java/uk/ac/sanger/sprint/service/language/CsvAdapterTest.java
+++ b/src/test/java/uk/ac/sanger/sprint/service/language/CsvAdapterTest.java
@@ -1,0 +1,52 @@
+package uk.ac.sanger.sprint.service.language;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import uk.ac.sanger.sprint.model.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+
+/** Test {@link CsvAdapter} */
+public class CsvAdapterTest {
+
+    CsvAdapter adapter = new CsvAdapter(",");
+
+    @Test
+    public void testTranscribe() {
+        PrintRequest request = new PrintRequest(Arrays.asList(
+                Layout.ofKeyFields("A", "Alpha", "B", "Beta", "C", "Gamma", "", null),
+                Layout.ofKeyFields("", "Alabama", "", null, "", "Calif,\nornia")
+        ));
+        String output = adapter.transcribe(request, null);
+        assertEquals(output, "Alpha,Beta,Gamma,\nAlabama,,Calif ornia");
+    }
+
+    @Test
+    public void testTranscribeKeyFields() {
+        List<KeyField> kfs = Arrays.asList(
+                new KeyField("", "Alpha"), new KeyField("", null), new KeyField("", ""),
+                new KeyField("", "Alpha  \n Beta"), new KeyField("", "Gamma,\tDelta")
+        );
+        String line = adapter.transcribeKeyFields(kfs);
+        assertEquals(line, "Alpha,,,Alpha Beta,Gamma Delta");
+    }
+
+    @Test(dataProvider="sanitiseValueArgs")
+    public void testSanitiseValue(String input, String expected) {
+        assertEquals(adapter.sanitiseValue(input), expected);
+    }
+
+    @DataProvider(name="sanitiseValueArgs")
+    Object[][] sanitiseValueArgs() {
+        return new Object[][] {
+                { "", "" },
+                { null, "" },
+                { "Alpha, Beta", "Alpha Beta"},
+                { "Alpha\nBeta", "Alpha Beta"},
+                { "Alpha\t,\n   Beta", "Alpha Beta"},
+        };
+    }
+}

--- a/src/test/java/uk/ac/sanger/sprint/service/language/PrinterLanguageAdapterFactoryTest.java
+++ b/src/test/java/uk/ac/sanger/sprint/service/language/PrinterLanguageAdapterFactoryTest.java
@@ -2,13 +2,11 @@ package uk.ac.sanger.sprint.service.language;
 
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import uk.ac.sanger.sprint.model.Printer;
-import uk.ac.sanger.sprint.model.PrinterLanguage;
-import uk.ac.sanger.sprint.model.PrinterType;
-import uk.ac.sanger.sprint.model.Protocol;
+import uk.ac.sanger.sprint.model.*;
 
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
+import java.nio.file.Paths;
+
+import static org.testng.Assert.*;
 
 /**
  * Tests for the implementation of {@link PrinterLanguageAdapterFactory}
@@ -26,22 +24,25 @@ public class PrinterLanguageAdapterFactoryTest {
     @Test
     public void testJScript() {
         PrinterType pt = new PrinterType("mypt", PrinterLanguage.JSCRIPT, Protocol.FTP, null, null, null);
-        Printer printer = new Printer("myprinter", pt, null);
+        Printer printer = new Printer("myprinter", pt, null, null);
         PrinterLanguageAdapter adapter = languageAdapterFactory.getLanguageAdapter(printer);
         assertNotNull(adapter);
         assertTrue(adapter instanceof JScriptAdapter);
     }
 
     @Test
+    public void testCsv() {
+        PrinterType pt = new PrinterType("mypy", PrinterLanguage.CSV, Protocol.VOLUME, null, null, null);
+        Printer printer = new Printer("myprinter", pt, null, Paths.get("path","printer"));
+        PrinterLanguageAdapter adapter = languageAdapterFactory.getLanguageAdapter(printer);
+        assertNotNull(adapter);
+        assertTrue(adapter instanceof CsvAdapter);
+    }
+
+    @Test
     public void testWithNullForPrinterLanguage() {
         PrinterType pt = new PrinterType("mypt", null, Protocol.FTP, null, null, null);
-        Printer printer = new Printer("myprinter", pt, null);
-        UnsupportedOperationException uoe = null;
-        try {
-            languageAdapterFactory.getLanguageAdapter(printer);
-        } catch (UnsupportedOperationException e) {
-            uoe = e;
-        }
-        assertNotNull(uoe);
+        Printer printer = new Printer("myprinter", pt, null, null);
+        assertThrows(UnsupportedOperationException.class, () -> languageAdapterFactory.getLanguageAdapter(printer));
     }
 }

--- a/src/test/java/uk/ac/sanger/sprint/service/protocol/FtpPrintProtocolAdapterTest.java
+++ b/src/test/java/uk/ac/sanger/sprint/service/protocol/FtpPrintProtocolAdapterTest.java
@@ -1,9 +1,7 @@
 package uk.ac.sanger.sprint.service.protocol;
 
 import org.mockito.Mock;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.testng.annotations.*;
 import uk.ac.sanger.sprint.model.*;
 
 import java.io.IOException;
@@ -11,7 +9,7 @@ import java.io.IOException;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 import static org.testng.Assert.assertNotNull;
 
 /**
@@ -32,20 +30,27 @@ public class FtpPrintProtocolAdapterTest {
 
     private FtpPrintProtocolAdapter adapter;
 
+    private AutoCloseable mocking;
+
     @BeforeClass
     private void setup() throws IOException {
         credentials = new Credentials("jeff", "swordfish");
         PrinterType printerType = new PrinterType("ftpprinter", PrinterLanguage.JSCRIPT, Protocol.FTP,
                 null, credentials, null);
         LabelType labelType = new LabelType(30, 12, 16, "tiny");
-        printer = new Printer("myprinter", printerType, labelType);
+        printer = new Printer("myprinter", printerType, labelType, null);
     }
 
     @BeforeMethod
     private void setupMocks() {
-        initMocks(this);
+        mocking = openMocks(this);
         when(mockFtpStoreFactory.getFTPStore(any(), any(), any())).thenReturn(mockFtpStore);
         adapter = new FtpPrintProtocolAdapter(printer, mockFtpStoreFactory, IPADDRESS);
+    }
+
+    @AfterMethod
+    private void releaseMocks() throws Exception {
+        mocking.close();
     }
 
     @Test

--- a/src/test/java/uk/ac/sanger/sprint/service/protocol/PrintProtocolAdapterFactoryTest.java
+++ b/src/test/java/uk/ac/sanger/sprint/service/protocol/PrintProtocolAdapterFactoryTest.java
@@ -3,12 +3,11 @@ package uk.ac.sanger.sprint.service.protocol;
 import org.springframework.boot.ApplicationArguments;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import uk.ac.sanger.sprint.model.Printer;
-import uk.ac.sanger.sprint.model.PrinterLanguage;
-import uk.ac.sanger.sprint.model.PrinterType;
-import uk.ac.sanger.sprint.model.Protocol;
+import uk.ac.sanger.sprint.model.*;
 import uk.ac.sanger.sprint.service.language.PrinterLanguageAdapterFactory;
+import uk.ac.sanger.sprint.utils.UniqueInstantSupplier;
 
+import java.time.Clock;
 import java.util.Collections;
 
 import static org.mockito.Mockito.mock;
@@ -28,12 +27,13 @@ public class PrintProtocolAdapterFactoryTest {
     private void setup() {
         ApplicationArguments mockApplicationArguments = mock(ApplicationArguments.class);
         when(mockApplicationArguments.getOptionValues("ipAddress")).thenReturn(Collections.singletonList("1.2.3.4"));
-        protocolAdapterFactory = new PrintProtocolAdapterFactoryImplementation(null, mockApplicationArguments);
+        UniqueInstantSupplier instantSupplier = new UniqueInstantSupplier(Clock.systemUTC());
+        protocolAdapterFactory = new PrintProtocolAdapterFactoryImplementation(null, mockApplicationArguments, instantSupplier);
     }
 
     private Printer printer(Protocol protocol) {
         PrinterType pt = new PrinterType("mypt", PrinterLanguage.JSCRIPT, protocol, null, null, null);
-        return new Printer("myprinter", pt, null);
+        return new Printer("myprinter", pt, null, null);
     }
 
     @Test
@@ -41,6 +41,13 @@ public class PrintProtocolAdapterFactoryTest {
         PrintProtocolAdapter adapter = protocolAdapterFactory.getPrintProtocolAdapter(printer(Protocol.FTP));
         assertNotNull(adapter);
         assertTrue(adapter instanceof FtpPrintProtocolAdapter);
+    }
+
+    @Test
+    public void testVolume() {
+        PrintProtocolAdapter adapter = protocolAdapterFactory.getPrintProtocolAdapter(printer(Protocol.VOLUME));
+        assertNotNull(adapter);
+        assertTrue(adapter instanceof VolumeProtocolAdapter);
     }
 
     @Test

--- a/src/test/java/uk/ac/sanger/sprint/service/protocol/VolumeProtocolAdapterTest.java
+++ b/src/test/java/uk/ac/sanger/sprint/service/protocol/VolumeProtocolAdapterTest.java
@@ -1,0 +1,56 @@
+package uk.ac.sanger.sprint.service.protocol;
+
+import org.springframework.util.FileSystemUtils;
+import org.testng.annotations.*;
+import uk.ac.sanger.sprint.model.Printer;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/** Test {@link VolumeProtocolAdapter} */
+public class VolumeProtocolAdapterTest {
+    String expectedFilename;
+    Path printerPath;
+    VolumeProtocolAdapter adapter;
+
+    @BeforeClass
+    public void setup() throws IOException {
+        Printer printer = mock(Printer.class);
+        printerPath = Paths.get("volumeProtocolAdapterTestDir");
+        when(printer.getPath()).thenReturn(printerPath);
+        DateTimeFormatter timeFormat = PrintProtocolAdapterFactoryImplementation.makeDateTimeFormatter();
+        Instant instant = LocalDateTime.of(2022, 1, 5, 12, 0, 0, 987654321).toInstant(ZoneOffset.UTC);
+        expectedFilename = "2022-01-05T12:00:00.987654321.csv";
+        adapter = new VolumeProtocolAdapter(printer, timeFormat, () -> instant);
+        Files.createDirectory(printerPath);
+    }
+
+    @AfterClass
+    public void tearDown() throws IOException {
+        FileSystemUtils.deleteRecursively(printerPath);
+    }
+
+    @Test
+    public void testNewFilename() {
+        assertEquals(expectedFilename, adapter.newFilename());
+    }
+
+    @Test
+    public void testPrint() throws IOException {
+        adapter.print("A,B,C,,D\nA,B,,C,D");
+        Path path = printerPath.resolve(expectedFilename);
+        assertTrue(Files.isRegularFile(path));
+        List<String> lines = Files.readAllLines(path);
+        assertEquals(lines.size(), 2);
+        assertEquals(lines.get(0), "A,B,C,,D");
+        assertEquals(lines.get(1), "A,B,,C,D");
+    }
+}

--- a/src/test/java/uk/ac/sanger/sprint/utils/UniqueInstantSupplierTest.java
+++ b/src/test/java/uk/ac/sanger/sprint/utils/UniqueInstantSupplierTest.java
@@ -1,0 +1,53 @@
+package uk.ac.sanger.sprint.utils;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.*;
+import java.util.stream.IntStream;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+/**
+ * Tests {@link UniqueInstantSupplier}
+ */
+public class UniqueInstantSupplierTest {
+    @Test(dataProvider = "clocks")
+    public void testNewInstant(Clock clock) {
+        final Instant start = clock.instant();
+        UniqueInstantSupplier uts = new UniqueInstantSupplier(clock);
+        Instant[] instants = IntStream.range(0,3)
+                .mapToObj(x -> uts.get())
+                .toArray(Instant[]::new);
+        Instant end = clock.instant();
+        if (start.equals(end)) {
+            assertEquals(instants[0], start);
+        } else {
+            assertNotBefore(instants[0], start);
+            assertNotBefore(end.plusNanos(instants.length), instants[instants.length-1]);
+        }
+        for (int i = 1; i < instants.length; ++i) {
+            assertBefore(instants[i-1], instants[i]);
+            assertBefore(instants[i], instants[i-1].plusSeconds(1));
+        }
+    }
+
+    private static void assertBefore(Instant a, Instant b) {
+        if (!a.isBefore(b)) {
+            fail(a+" should be before "+b);
+        }
+    }
+
+    private static void assertNotBefore(Instant a, Instant b) {
+        if (a.isBefore(b)) {
+            fail(a+" should be after or equal to "+b);
+        }
+    }
+
+    @DataProvider(name="clocks")
+    public Object[][] clocks() {
+        return new Object[][]{ {Clock.systemUTC()}, {Clock.fixed(Instant.now(), ZoneOffset.UTC)} };
+    }
+
+}


### PR DESCRIPTION
Support cassette printing

Accept key/value fields in SPrint print request.
Convert request to CSV.
Save CSV in a directory that is intended to be a mounted volume.

(The printer should pick up the CSV file from the network volume.)